### PR TITLE
Fix axios environment variable not set correctly in docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,13 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm install
 COPY . .
-RUN npm run build
 
 ARG API_URL
 ENV API_URL $API_URL
 ENV HOST 0.0.0.0
 ENV PORT 3000
+
+RUN npm run build
 
 EXPOSE 3000
 


### PR DESCRIPTION
### Description

Axios configuration for base url in `nuxt.config.js` file was not set correctly because axios can't read environment variables during the build process. Instead, localhost was used as a fallback.

<img width="994" alt="Screen Shot 2021-08-23 at 11 29 49" src="https://user-images.githubusercontent.com/55199533/130391572-d43a9678-9f67-4ff0-87a5-19b77d833c9d.png">

### Changes

- Update dockerfile