### PR TITLE
Improve Breadcrumb Component

### DIFF
--- a/components/Breadcrumb/index.vue
+++ b/components/Breadcrumb/index.vue
@@ -18,6 +18,14 @@ export default {
   name: 'Breadcrumb',
   props: {
     /**
+     * Predefined array of breadcrumb items
+     * Use this props to override default breadcrumb item list.
+     */
+    items: {
+      type: Array,
+      default: () => []
+    },
+    /**
      * Array of hidden breadcrumb item
      */
     hideItems: {
@@ -27,6 +35,13 @@ export default {
   },
   computed: {
     breadcrumbItems () {
+      /**
+       * return list of `items` props if defined
+       */
+      if (Array.isArray(this.items) && this.items.length > 0) {
+        return this.items
+      }
+
       const fullPath = this.$route.path
       const params = fullPath.substring(1).split('/')
       const crumbs = []

--- a/components/Breadcrumb/index.vue
+++ b/components/Breadcrumb/index.vue
@@ -3,11 +3,14 @@
     <template v-for="(item, index) in breadcrumbItems">
       <nuxt-link
         :key="index"
-        :to="item.fullPath"
-        class="breadcrumb__item font-roboto capitalize text-sm flex items-center"
-        :class="item.fullPath === activeRoute ? 'font-bold text-white' : 'text-blue-400'"
+        :to="item.path"
+        class="breadcrumb__item font-roboto text-sm flex items-center"
+        :class="[
+          item.path === activeRoute ? 'font-bold text-white' : 'text-blue-400',
+          items.length ? '' : 'capitalize'
+        ]"
       >
-        {{ item.pathName }}
+        {{ item.label }}
       </nuxt-link>
     </template>
   </section>
@@ -36,7 +39,7 @@ export default {
   computed: {
     breadcrumbItems () {
       /**
-       * return list of `items` props if defined
+       * return `items` props if defined
        */
       if (Array.isArray(this.items) && this.items.length > 0) {
         return this.items
@@ -49,16 +52,16 @@ export default {
 
       // Add homepage to first index of breadcrumb items
       crumbs.push({
-        fullPath: '/',
-        pathName: 'beranda'
+        path: '/',
+        label: 'beranda'
       })
 
       params.map((param) => {
         path = `${path}/${param}`
 
         crumbs.push({
-          fullPath: path,
-          pathName: param.replace('/', '').replaceAll('-', ' ')
+          path,
+          label: param.replace('/', '').replaceAll('-', ' ')
         })
 
         return null


### PR DESCRIPTION
#### Overview
The default behavior of the `Breadcrumb` component is to render a list of routes based on the current browser route using `$route.path` . However, this is not always the desired behavior, sometimes we want a custom list of breadcrumb paths and item labels, so it makes sense to add an `items` prop to handle this scenario.

#### Changes
- add `items` props
- adjust object property name
- remove `capitalize` style when `items` props is defined