### PR TITLE
refactor: move calendar navigation into its own component

### DIFF
--- a/components/Agenda/Calendar/index.vue
+++ b/components/Agenda/Calendar/index.vue
@@ -1,47 +1,23 @@
 <template>
-  <div class="flex flex-col gap-9">
-    <div class="flex justify-between items-center">
-      <div class="flex justify-between items-center gap-5">
-        <div class="flex gap-4">
-          <Icon
-            name="chevron-left"
-            class="text-green-800 cursor-pointer"
-            size="18px"
-            @click="prevMonth"
-          />
-          <Icon
-            name="chevron-right"
-            class="text-green-800 cursor-pointer"
-            size="18px"
-            @click="nextMonth"
-          />
-        </div>
-        <p class="font-roboto font-bold text-3xl">
-          {{ month }}
-          <span class="font-medium text-gray-500">{{ year }}</span>
-        </p>
-      </div>
-      <Select
-        label="Tampilkan dalam"
-        :options="[{ value: 'month', label: 'Bulan' }, { value: 'week', label: 'Minggu' }]"
-        value="month"
-      />
-    </div>
-    <FullCalendar ref="fullCalendar" :options="calendarOptions" />
-  </div>
+  <FullCalendar ref="fullCalendar" :options="calendarOptions" />
 </template>
 
 <script>
 import FullCalendar from '@fullcalendar/vue'
 import dayGridPlugin from '@fullcalendar/daygrid'
 import idLocale from '@fullcalendar/core/locales/id'
-import { format, formatISODate } from '~/utils/date'
+import { formatISODate } from '~/utils/date'
 
 export default {
   components: {
     FullCalendar
   },
   props: {
+    calendarApi: {
+      type: Object,
+      required: false,
+      default: null
+    },
     selectedDate: {
       type: Date,
       required: true
@@ -49,7 +25,6 @@ export default {
   },
   data () {
     return {
-      calendarApi: null,
       calendarOptions: {
         plugins: [dayGridPlugin],
         initialView: 'dayGridMonth',
@@ -66,32 +41,15 @@ export default {
       }
     }
   },
-  computed: {
-    date () {
-      return this.calendarApi ? this.calendarApi.getDate() : new Date()
-    },
-    month () {
-      return format(this.date, { month: 'long' })
-    },
-    year () {
-      return format(this.date, { year: 'numeric' })
-    }
-  },
   watch: {
     selectedDate (date) {
       this.calendarApi.gotoDate(date)
     }
   },
   mounted () {
-    this.calendarApi = this.$refs.fullCalendar.getApi()
+    this.$emit('update:calendar-api', this.$refs.fullCalendar.getApi())
   },
   methods: {
-    nextMonth () {
-      this.changeSelectedDate('nextMonth')
-    },
-    prevMonth () {
-      this.changeSelectedDate('prevMonth')
-    },
     dayCellClassNames ({ date }) {
       const currentDate = formatISODate(date)
       const selectedDate = formatISODate(this.selectedDate)
@@ -133,27 +91,6 @@ export default {
         // silent error
         return []
       }
-    },
-    /**
-     * change `selectedDate` based on action
-     * @param {string} action
-     * @return {Event}
-     */
-    changeSelectedDate (action) {
-      const date = this.calendarApi.getDate()
-
-      if (action === 'nextMonth') {
-        const firstDayOfMonth = new Date(date.getFullYear(), date.getMonth() + 1, 1) // get first date of next month
-        return this.$emit('change', firstDayOfMonth)
-      }
-
-      if (action === 'prevMonth') {
-        const lastDayOfMonth = new Date(date.getFullYear(), date.getMonth(), 0) // get last date of prev month
-        return this.$emit('change', lastDayOfMonth)
-      }
-
-      // TODO : add event on date click
-      return null
     }
   }
 }

--- a/components/Agenda/List/index.vue
+++ b/components/Agenda/List/index.vue
@@ -42,6 +42,11 @@ import { addDay, format, formatISODate, isCurrentDay } from '~/utils/date'
 
 export default {
   props: {
+    calendarApi: {
+      type: Object,
+      required: false,
+      default: null
+    },
     selectedDate: {
       type: Date,
       default: () => new Date()

--- a/components/Agenda/Navigation/index.vue
+++ b/components/Agenda/Navigation/index.vue
@@ -1,0 +1,92 @@
+<template>
+  <div class="flex justify-between items-center">
+    <div class="flex justify-between items-center gap-5">
+      <div class="flex gap-4">
+        <Icon
+          name="chevron-left"
+          class="text-green-800 cursor-pointer"
+          size="18px"
+          @click="prevMonth"
+        />
+        <Icon
+          name="chevron-right"
+          class="text-green-800 cursor-pointer"
+          size="18px"
+          @click="nextMonth"
+        />
+      </div>
+      <p class="font-roboto font-bold text-3xl">
+        {{ month }}
+        <span class="font-medium text-gray-500">{{ year }}</span>
+      </p>
+    </div>
+    <Select
+      label="Tampilkan dalam"
+      :options="[{ value: 'month', label: 'Bulan' }, { value: 'week', label: 'Minggu' }]"
+      value="month"
+    />
+  </div>
+</template>
+
+<script>
+import { format } from '~/utils/date'
+
+export default {
+  props: {
+    calendarApi: {
+      type: Object,
+      required: false,
+      default: null
+    },
+    selectedDate: {
+      type: Date,
+      required: true
+    }
+  },
+  computed: {
+    date () {
+      return this.calendarApi ? this.calendarApi.getDate() : new Date()
+    },
+    month () {
+      return format(this.date, { month: 'long' })
+    },
+    year () {
+      return format(this.date, { year: 'numeric' })
+    }
+  },
+  watch: {
+    selectedDate (date) {
+      this.calendarApi.gotoDate(date)
+    }
+  },
+  methods: {
+    nextMonth () {
+      this.changeSelectedDate('nextMonth')
+    },
+    prevMonth () {
+      this.changeSelectedDate('prevMonth')
+    },
+    /**
+     * change `selectedDate` based on action
+     * @param {string} action
+     * @return {Event}
+     */
+    changeSelectedDate (action) {
+      const date = this.calendarApi.getDate()
+
+      if (action === 'nextMonth') {
+        const firstDayOfMonth = new Date(date.getFullYear(), date.getMonth() + 1, 1) // get first date of next month
+        return this.$emit('change', firstDayOfMonth)
+      }
+
+      if (action === 'prevMonth') {
+        const lastDayOfMonth = new Date(date.getFullYear(), date.getMonth(), 0) // get last date of prev month
+        return this.$emit('change', lastDayOfMonth)
+      }
+
+      // TODO : add event on date click
+      return null
+    }
+  }
+}
+</script>

--- a/components/Agenda/index.vue
+++ b/components/Agenda/index.vue
@@ -2,8 +2,20 @@
   <div class="relative -top-24 z-10">
     <BaseContainer>
       <div class="bg-white p-10 rounded-xl shadow flex flex-col gap-7">
-        <AgendaCalendar :selected-date="selectedDate" @change="setSelectedDate" />
-        <AgendaList :selected-date="selectedDate" @change="setSelectedDate" />
+        <AgendaNavigation
+          :calendar-api="calendarApi"
+          :selected-date="selectedDate"
+          @change="setSelectedDate"
+        />
+        <AgendaCalendar
+          :calendar-api.sync="calendarApi"
+          :selected-date="selectedDate"
+          @change="setSelectedDate"
+        />
+        <AgendaList
+          :selected-date="selectedDate"
+          @change="setSelectedDate"
+        />
       </div>
     </BaseContainer>
   </div>
@@ -13,6 +25,7 @@
 export default {
   data () {
     return {
+      calendarApi: null,
       selectedDate: new Date()
     }
   },


### PR DESCRIPTION
### Overview

There's a navigation template inside `AgendaCalendar` component that should be move into its own component.

```diff
<BaseContainer>
+ <AgendaNavigation />
  <AgendaCalendar />
  <AgendaList />
<BaseContainer />
```

### Changes

- Create `AgendaCalendar` component
- Move `calendarApi` data to the parent

### Evidence
project: Portal Jabar
title: Refactor move calendar navigation into its own component
participants: 