### PR TITLE
Remove keen slider for carousel and create our own carouse component

### DIFF
--- a/components/Carousel/index.vue
+++ b/components/Carousel/index.vue
@@ -1,34 +1,34 @@
 <template>
   <div
-    ref="slider"
-    class="w-full h-full relative overflow-hidden"
+    class="w-full h-full overflow-hidden relative"
     :class="{'group': hover}"
     @mouseover="setPause(pauseOnHover)"
     @mouseout="setPause(false)"
   >
-    <div
-      v-for="(item, index) in items"
-      :key="index"
-      class="w-full h-full absolute top-0"
-      :style="{ opacity: opacities[index] }"
-    >
-      <div class="keen-slider__slide w-full h-full relative">
-        <img
-          class="w-full h-full object-cover object-center transition duration-500 ease-in-out"
-          :class="{ 'group-hover:transform group-hover:scale-110': hover }"
-          :src="item.image"
-          :alt="item.title"
-        >
-        <slot name="filter" />
-        <slot :item="item" :index="index" :slider="slider" />
-      </div>
-    </div>
+    <template v-for="(item, index) in items">
+      <transition :key="index" name="fade" tag="div" mode="out-in">
+        <div v-show="index === currentIndex" class="w-full h-full">
+          <img
+            :src="item.image"
+            class="object-cover object-center w-full h-full"
+            :class="{ 'transition duration-500 ease-in-out group-hover:transform group-hover:scale-110': hover }"
+          >
+          <slot name="filter" />
+          <slot
+            name="content"
+            :item="item"
+            :index="index"
+            :current-index="currentIndex"
+            :prev="prev"
+            :next="next"
+          />
+        </div>
+      </transition>
+    </template>
   </div>
 </template>
 
 <script>
-import KeenSlider from 'keen-slider'
-
 export default {
   props: {
     items: {
@@ -40,56 +40,34 @@ export default {
       required: false,
       default: 3000
     },
-    speed: {
-      type: Number,
-      required: false,
-      default: 3000
-    },
     hover: {
       type: Boolean,
       required: false,
-      default: true
+      default: false
     },
     pauseOnHover: {
       type: Boolean,
       required: false,
-      default: true
+      default: false
     }
   },
   data () {
     return {
-      opacities: [],
-      slider: null,
-      interval: null
+      interval: null,
+      currentIndex: 0,
+      pause: false
     }
   },
   mounted () {
-    this.slider = new KeenSlider(this.$refs.slider, {
-      pause: false,
-      slides: this.items.length,
-      loop: true,
-      duration: this.speed,
-      move: (s) => {
-        const opacities = s.details().positions.map(slide => slide.portion)
-        this.setOpacities(opacities)
-      }
-    })
-    this.setInterval()
+    this.startSlide()
   },
-  beforeDestroy () {
-    if (this.slider) {
-      this.slider.destroy()
-    }
-  },
+
   methods: {
-    setOpacities (opacities) {
-      this.opacities = opacities
-    },
-    setInterval () {
+    startSlide () {
       this.resetInterval()
       this.interval = setInterval(() => {
         if (!this.pause) {
-          this.slider.next()
+          this.next()
         }
       }, this.duration)
     },
@@ -99,9 +77,40 @@ export default {
     setPause (active) {
       this.pause = active
       if (this.pauseOnHover) {
-        this.setInterval()
+        this.startSlide()
+      }
+    },
+    next () {
+      if (this.currentIndex >= this.items.length - 1) {
+        this.currentIndex = 0
+      } else {
+        this.currentIndex += 1
+      }
+    },
+    prev () {
+      if (this.currentIndex <= 0) {
+        this.currentIndex = this.items.length - 1
+      } else {
+        this.currentIndex -= 1
       }
     }
   }
 }
 </script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: all 0.9s ease;
+  overflow: hidden;
+  visibility: visible;
+  position: absolute;
+  opacity: 1;
+}
+
+.fade-enter,
+.fade-leave-to {
+  visibility: hidden;
+  opacity: 0;
+}
+</style>

--- a/components/Hero/Image/index.vue
+++ b/components/Hero/Image/index.vue
@@ -1,10 +1,17 @@
 <template>
   <div class="h-screen">
-    <Carousel :items="items" />
     <div
       class="w-full h-screen absolute top-0"
       style="background: linear-gradient(100deg, rgba(0,40,19,0.9) 0%, rgba(0,32,39,0.8) 55%);"
     />
+    <Carousel :items="items">
+      <template #filter>
+        <div
+          class="w-full h-screen absolute top-0"
+          style="background: linear-gradient(100deg, rgba(0,40,19,0.9) 0%, rgba(0,32,39,0.8) 55%);"
+        />
+      </template>
+    </Carousel>
   </div>
 </template>
 

--- a/components/LatestNews/Preview/index.vue
+++ b/components/LatestNews/Preview/index.vue
@@ -1,10 +1,7 @@
 <template>
   <div class="col-span-5 rounded-lg overflow-hidden">
-    <Carousel
-      :items="items"
-      :speed="1000"
-    >
-      <template #default="{ item, index, slider }">
+    <Carousel :items="items" hover pause-on-hover>
+      <template #content="{ item, currentIndex, prev, next }">
         <div
           class="absolute bottom-0 w-full bg-black bg-opacity-50 transition duration-500 ease-in-out group-hover:bg-opacity-70 backdrop-filter backdrop-blur-lg rounded-lg px-8 py-6 text-white"
           style="height: 47%"
@@ -25,24 +22,24 @@
                 <div>|</div>
                 <div class="flex items-center gap-2">
                   <Icon src="/icons/pen.svg" size="16px" alt="Penulis" />
-                  <p>Penulis: {{ item.created_by }}</p>
+                  <p>Penulis: {{ item.author.name }}</p>
                 </div>
               </div>
             </div>
             <div class="flex justify-between items-center">
-              <Link :link="`/berita/${getSlug(slider)}`">
+              <Link :link="`/berita/${item.slug}`">
                 <button type="button" class="text-sm border border-white border-opacity-30 px-4 py-2 rounded-lg">
                   Baca Selengkapnya
                 </button>
               </Link>
               <div class="flex items-center gap-4">
-                <div class="cursor-pointer" @click="slider.prev()">
+                <div class="cursor-pointer" @click="prev">
                   <Icon name="chevron-left" size="10px" />
                 </div>
                 <p class="text-sm text-gray-500">
-                  <span class="font-bold text-white mr-1">{{ index + 1 }}</span>dari {{ items.length }}
+                  <span class="font-bold text-white mr-1">{{ currentIndex + 1 }}</span>dari {{ items.length }}
                 </p>
-                <div class="cursor-pointer" @click="slider.next()">
+                <div class="cursor-pointer" @click="next">
                   <Icon name="chevron-right" size="10px" />
                 </div>
               </div>
@@ -50,7 +47,7 @@
           </div>
         </div>
       </template>
-    </carousel>
+    </Carousel>
   </div>
 </template>
 

--- a/components/News/Header/index.vue
+++ b/components/News/Header/index.vue
@@ -5,25 +5,19 @@
         <Breadcrumb class="mb-6" />
       </BaseContainer>
     </div>
-    <div style="height: 625px;">
+    <div class="w-full" style="height: 625px;">
       <div
         class="w-full absolute top-0 h-full"
         style="background: linear-gradient(100deg, rgba(0,40,19,0.9) 0%, rgba(0,32,39,0.8) 55%);"
       />
-      <Carousel
-        :items="items"
-        :duration="10000"
-        :speed="1000"
-        :hover="false"
-        :pause-on-hover="false"
-      >
+      <Carousel :items="items" :duration="10000" pause-on-hover>
         <template #filter>
           <div
-            class="w-full absolute top-0 h-full"
+            class="w-full h-full absolute top-0"
             style="background: radial-gradient(circle, rgba(0,23,28,0.08) 0%, rgba(0,11,14,0.59) 50%, rgba(0,11,14,0.82) 100%);"
           />
         </template>
-        <template #default="{ item, index, slider }">
+        <template #content="{ item, currentIndex, prev, next }">
           <div class="absolute bottom-0 w-full text-white">
             <BaseContainer class="grid grid-cols-1 lg:grid-cols-9">
               <div class="flex flex-col justify-end h-full lg:col-span-6 lg:pr-20 xl:pr-32 pb-10">
@@ -49,19 +43,19 @@
                   </div>
                 </div>
                 <div class="flex justify-between items-center">
-                  <Link :link="`/berita/${getSlug(slider)}`">
+                  <Link :link="`/berita/${item.slug}`">
                     <button type="button" class="border border-white border-opacity-30 px-4 py-2 rounded-lg">
                       Baca Selengkapnya
                     </button>
                   </Link>
                   <div class="flex items-center gap-4">
-                    <div class="cursor-pointer" @click="slider.prev()">
+                    <div class="cursor-pointer" @click="prev">
                       <Icon name="chevron-left" size="10px" />
                     </div>
                     <p class="text-gray-500">
-                      <span class="font-bold text-white mr-1">{{ index + 1 }}</span>dari {{ items.length }}
+                      <span class="font-bold text-white mr-1">{{ currentIndex + 1 }}</span>dari {{ items.length }}
                     </p>
-                    <div class="cursor-pointer" @click="slider.next()">
+                    <div class="cursor-pointer" @click="next">
                       <Icon name="chevron-right" size="10px" />
                     </div>
                   </div>
@@ -72,26 +66,26 @@
                   Berita Terkait
                 </p>
                 <div class="flex flex-col gap-2">
-                  <Link v-for="(news, idx) of item.related_news" :key="news.id" :link="`/berita/${getRelatedNewsSlug(slider, idx)}`">
-                    <div class="flex gap-4 p-2 bg-white bg-opacity-0 rounded-xl">
+                  <Link v-for="news of item.related_news.slice(0, 4)" :key="news.id" :link="`/berita/${news.slug}`" class="group">
+                    <div class="flex newss-center gap-4 p-2 bg-white bg-opacity-0 group-hover:bg-opacity-5 rounded-xl">
                       <div class="flex-shrink-0 overflow-hidden rounded-xl" style="width: 92px; height: 92px;">
                         <img
                           :src="news.image"
                           width="92"
                           height="92"
-                          class="flex-shrink-0 object-cover w-full h-full"
+                          class="flex-shrink-0 object-cover w-full h-full group-hover:transform group-hover:scale-110 transition duration-500 ease-in-out"
                         >
                       </div>
                       <div class="flex flex-col gap-1">
-                        <p class="text-xs font-medium uppercase opacity-50">
+                        <p class="text-xs font-medium uppercase opacity-50 group-hover:opacity-100">
                           {{ news.category }}
                         </p>
                         <p class="line-clamp-2 text-sm leading-relaxed">
                           {{ news.title }}
                         </p>
                         <div class="flex gap-2">
-                          <Icon src="/icons/calendar.svg" size="14px" alt="Diterbitkan" class="opacity-50" />
-                          <p class="text-xs opacity-50">
+                          <Icon src="/icons/calendar.svg" size="14px" alt="Diterbitkan" class="opacity-50 group-hover:opacity-100" />
+                          <p class="text-xs opacity-50 group-hover:opacity-100">
                             {{ formatDate(news.created_at) }}
                           </p>
                         </div>

--- a/components/News/Header/index.vue
+++ b/components/News/Header/index.vue
@@ -67,7 +67,7 @@
                 </p>
                 <div class="flex flex-col gap-2">
                   <Link v-for="news of item.related_news.slice(0, 4)" :key="news.id" :link="`/berita/${news.slug}`" class="group">
-                    <div class="flex newss-center gap-4 p-2 bg-white bg-opacity-0 group-hover:bg-opacity-5 rounded-xl">
+                    <div class="flex gap-4 p-2 bg-white bg-opacity-0 group-hover:bg-opacity-5 rounded-xl">
                       <div class="flex-shrink-0 overflow-hidden rounded-xl" style="width: 92px; height: 92px;">
                         <img
                           :src="news.image"


### PR DESCRIPTION
### Description

There's an issue with [keen-slider](https://keen-slider.io/) when it renders in the client-side. The library isn't working well with hybrid rendering.

Why not use another library instead? Most slider / carousel library for Vue.js work for client-side rendering, there's a few library that support server-side rendering, like [keen-slider](https://keen-slider.io/) but not hybrid rendering.

### Solution

We create our own simple carousel to provide both client-side rendering and server-side rendering. These change spesific for our current use case.

### Changes

- Create carousel component
- Replace all component that used old carousel to the new one

### Evidence

Project: Portal Jabar
Title: Remove keen slider for carousel and create our own carouse component
Participants: @bangunbagustapa @Ibwedagama @adzharamrullah @naufalihsank 