### PR TITLE
Fix: set year correctly on agenda navigation

### DIFF
--- a/components/Agenda/Navigation/index.vue
+++ b/components/Agenda/Navigation/index.vue
@@ -65,7 +65,9 @@ export default {
       return format(lastDayOfWeek, { month: 'long' })
     },
     year () {
-      return format(this.date, { year: 'numeric' })
+      const lastDayOfWeek = new Date(this.eachDayOfWeek[this.eachDayOfWeek.length - 1])
+
+      return format(lastDayOfWeek, { year: 'numeric' })
     },
     isMonthView () {
       return this.agendaView === 'month'


### PR DESCRIPTION
### Related Tasks

- [T23 - Kalendar Mingguan - Range tanggal diantara 2 bulan - FE](https://airtable.com/app7SdZInMN1pG6ZL/tblB9pTkT5LrZHnIp/viwQAZLJD0D9EGBbX/rec8OrloFXHrWoDYM?blocks=hide)

### Evidence

Project: Portal Jabar
Title: Set year correctly on agenda navigation
Participants: @bangunbagustapa @Ibwedagama @naufalihsank @maulanayuseph 