### PR TITLE
Fix Pagination Popover Z-Index

### DIFF
--- a/components/Pagination/index.vue
+++ b/components/Pagination/index.vue
@@ -45,6 +45,6 @@ export default {
   width: 100% !important;
 }
 .jds-popover__content {
-  z-index: 2 !important;
+  z-index: 20 !important;
 }
 </style>


### PR DESCRIPTION
#### Overview
- Currently, the `Pagination` component's popover has a lower `z-index` value than the `NewsVideoHeadline` component, this causes problems when user tries to change the _item per page_ and _page_ values ​​using the _select dropdown_. they will accidentally click on the `NewsVideoHeadline` component and open a new tab.
- To fix this issue we need to add a higher `z-index` value on `Pagination` popover

#### Preview of the issue
![Peek 2021-11-11 09-34](https://user-images.githubusercontent.com/33661143/141227103-e4cd17dc-f7ca-40b0-8310-2746b246ff40.gif)

### Evidence

project: Portal Jabar
title: Fix pagination popover z-index
participants: @Ibwedagama @maruf12 @bangunbagustapa @naufalihsank @yoslie 
