### PR TITLE
Fix: remove click event on NewsItem component

### DIFF
--- a/components/News/Item/index.vue
+++ b/components/News/Item/index.vue
@@ -11,17 +11,18 @@
       class="cursor-pointer overflow-hidden rounded-lg transition-transform duration-300 ease-in-out"
       :class="loading ? 'bg-gray-200 animate-pulse' : ''"
       :style="imageSize"
-      @click="$emit('clicked', { id: item.id, slug: item.slug })"
     >
-      <img
-        v-show="!loading"
-        ref="news-item-image"
-        :src="item.image"
-        :alt="item.title"
-        class="block transition-transform object-center object-cover duration-300 ease-in-out
+      <Link :link="`/berita/${item.slug}`">
+        <img
+          v-show="!loading"
+          ref="news-item-image"
+          :src="item.image"
+          :alt="item.title"
+          class="block transition-transform object-center object-cover duration-300 ease-in-out
           group-hover:transform group-hover:scale-125"
-        :style="imageSize"
-      >
+          :style="imageSize"
+        >
+      </Link>
     </div>
     <div class="w-full flex flex-col items-start justify-center">
       <!-- skeleton -->
@@ -30,15 +31,16 @@
         <div class="w-1/2 h-4 bg-gray-200 animate-pulse rounded-md mb-2" />
       </div>
       <template v-else>
-        <h2
-          ref="news-item-title"
-          class="cursor-pointer font-lato font-medium text-blue-gray-800 mb-2
+        <Link :link="`/berita/${item.slug}`">
+          <h2
+            ref="news-item-title"
+            class="cursor-pointer font-lato font-medium text-blue-gray-800 mb-2
           group-hover:text-green-800 line-clamp-2"
-          :class="small ? 'text-base leading-6' : 'text-lg leading-7'"
-          @click="$emit('clicked', { id: item.id, slug: item.slug })"
-        >
-          {{ item.title }}
-        </h2>
+            :class="small ? 'text-base leading-6' : 'text-lg leading-7'"
+          >
+            {{ item.title }}
+          </h2>
+        </Link>
         <p ref="news-item-meta" class="font-normal text-xs leading-5 text-gray-700">
           <span class="group-hover:text-blue-gray-800 capitalize">{{ item.category }}</span> | {{ formatDate(item.date) }}
         </p>

--- a/components/News/List/index.vue
+++ b/components/News/List/index.vue
@@ -14,7 +14,6 @@
         :item="item"
         :small="small"
         :loading="loading"
-        @clicked="onNewsClick"
       />
     </div>
     <div ref="news-list-footer" class="w-full">
@@ -44,11 +43,6 @@ export default {
       type: Boolean,
       required: false,
       default: false
-    }
-  },
-  methods: {
-    onNewsClick ({ id, slug }) {
-      this.$router.push(`/berita/${slug}`)
     }
   }
 }

--- a/test/unit/NewsItem.spec.js
+++ b/test/unit/NewsItem.spec.js
@@ -63,17 +63,4 @@ describe('NewsItem Component', () => {
 
     expect(container.classes()).toContain('grid-cols-news-small')
   })
-
-  test('should emit `clicked` event when image and title clicked', async () => {
-    const title = wrapper.findComponent({ ref: 'news-item-title' })
-    const image = wrapper.findComponent({ ref: 'news-item-image' })
-
-    await title.trigger('click')
-
-    expect(wrapper.emitted().clicked[0]).toStrictEqual([{ id: 1, slug: 'dummy-slug' }])
-
-    await image.trigger('click')
-
-    expect(wrapper.emitted().clicked[0]).toStrictEqual([{ id: 1, slug: 'dummy-slug' }])
-  })
 })

--- a/test/unit/NewsItem.spec.js
+++ b/test/unit/NewsItem.spec.js
@@ -16,7 +16,8 @@ beforeEach(() => {
       },
       small: false,
       loading: false
-    }
+    },
+    stubs: ['Link']
   })
 })
 


### PR DESCRIPTION
#### Changes
- remove click events on `NewsItem` component and replace it with `Link` component
- remove `emit on click` test case on `NewsItem` test file

### Evidence
title: Remove click event on NewsItem component
project: Portal Jabar
participants: @Ibwedagama @maulanayuseph @adzharamrullah @bangunbagustapa @yoslie 

