### PR TITLE
Fix: change items per page options on pagination

### DIFF
--- a/components/Search/index.vue
+++ b/components/Search/index.vue
@@ -44,9 +44,9 @@ export default {
       loading: false,
       pagination: {
         currentPage: 1,
-        itemsPerPage: 5,
+        itemsPerPage: 6,
         totalRows: 0,
-        itemPerPageOptions: [5, 10, 15]
+        itemsPerPageOptions: [6, 9, 15]
       },
       searchKeyword: null,
       searchData: [],
@@ -134,6 +134,7 @@ export default {
         this.searchMeta = meta
 
         const paginationObj = {
+          ...this.pagination,
           currentPage: this.searchMeta.current_page,
           itemsPerPage: this.searchMeta.per_page,
           totalRows: this.searchMeta.total_count


### PR DESCRIPTION
#### Overview
- as described by the title

#### Changes
- change items per page options from `5, 10, 15` to `6, 9, 15`
- fix items per page bug when the user changes page

### Evidence
title: Change items per page options on pagination
project: Portal Jabar
participants: @Ibwedagama @maruf12 @bangunbagustapa @naufalihsank @yoslie 
