### PR TITLE
Fix: Search item skeletons loop

### DIFF
--- a/components/Search/List/index.vue
+++ b/components/Search/List/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="listView === 'list' ? 'w-full flex flex-col gap-8' : 'w-full grid grid-cols-3 gap-x-4 gap-y-8'">
     <template v-if="loading">
-      <SearchItemSkeleton v-for="item in 5" :key="item" :view="listView" />
+      <SearchItemSkeleton v-for="item in maxLength" :key="item" :view="listView" />
     </template>
     <template v-else>
       <SearchItem v-for="item in items" :key="item.id" :view="listView" :item="item" />
@@ -26,6 +26,10 @@ export default {
     loading: {
       type: Boolean,
       default: false
+    },
+    maxLength: {
+      type: Number,
+      default: 6
     }
   }
 }

--- a/components/Search/index.vue
+++ b/components/Search/index.vue
@@ -19,7 +19,12 @@
         <template v-else>
           <section class="w-full h-full min-h-screen flex flex-col gap-8">
             <SearchToolbar :list-view.sync="listView" :total-count="searchMeta.total_count" />
-            <SearchList :list-view="listView" :loading="loading" :items="searchData" />
+            <SearchList
+              :list-view="listView"
+              :loading="loading"
+              :items="searchData"
+              :max-length="pagination.itemsPerPage"
+            />
             <Pagination
               v-bind="pagination"
               @previous-page="onPaginationChange('prev-page', $event)"


### PR DESCRIPTION
#### Overview
- as described by the title

#### Changes
- add `maxLength` props on `SearchItemSkeleton` component
- adjust prop-binding on `Search` component

### Evidence
title: Fix search item skeletons render loop
project: Portal Jabar
participants: @Ibwedagama @maruf12 @adzharamrullah @bangunbagustapa 