### PR TITLE
Improve: related news section

### DIFF
--- a/components/News/List/Header/index.vue
+++ b/components/News/List/Header/index.vue
@@ -1,12 +1,11 @@
 <template>
-  <div class="w-full relative">
-    <div class="inline-block">
-      <h1 class="font-lato text-sm font-bold leading-6 mb-3 uppercase text-blue-gray-800">
+  <div class="flex w-full h-[38px] mb-6">
+    <div class="border-b-[3px] border-green-700">
+      <h1 class="whitespace-nowrap font-lato text-sm font-bold leading-6 uppercase text-blue-gray-800">
         {{ label }} <span v-if="category" class="text-gray-500">di {{ category }}</span>
       </h1>
-      <hr class="w-full bg-green-700" style="height: 3px">
-      <hr class="absolute w-full bg-blue-gray-50" style="height: 3px; bottom: 6px; z-index: -1">
     </div>
+    <div class="w-full h-full border-b-[3px] border-blue-gray-50" />
   </div>
 </template>
 

--- a/components/News/List/index.vue
+++ b/components/News/List/index.vue
@@ -4,17 +4,29 @@
       <slot name="header" />
     </div>
     <div
-      ref="news-list-body"
-      class="flex-auto w-full flex flex-col"
-      :class="small ? 'gap-5' : 'gap-6'"
+      :class="{
+        'w-full min-h-[138px]' : true,
+        'min-h-[88px]' : small
+      }"
+      :style="maxHeight ? {
+        maxHeight: maxHeight + 'px',
+        paddingRight: '16px',
+        overflowY: 'auto'
+      } : null"
     >
-      <NewsItem
-        v-for="item in items.slice(0, maxItem)"
-        :key="item.id"
-        :item="item"
-        :small="small"
-        :loading="loading"
-      />
+      <div
+        ref="news-list-body"
+        class="flex-auto w-full flex flex-col"
+        :class="small ? 'gap-5' : 'gap-6'"
+      >
+        <NewsItem
+          v-for="item in items.slice(0, maxItem)"
+          :key="item.id"
+          :item="item"
+          :small="small"
+          :loading="loading"
+        />
+      </div>
     </div>
     <div ref="news-list-footer" class="w-full">
       <slot name="footer" />
@@ -43,6 +55,11 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    },
+    maxHeight: {
+      type: [String, Number],
+      required: false,
+      default: null
     }
   }
 }

--- a/components/NewsDetail/index.vue
+++ b/components/NewsDetail/index.vue
@@ -11,8 +11,8 @@
           </div>
           <!-- Related News and Share Buttons -->
           <section class="w-[400px] h-full">
-            <div class="flex flex-col gap-7">
-              <NewsList :items="relatedNews" small :loading="loading">
+            <div class="flex flex-col gap-7 md:sticky md:top-[88px]">
+              <NewsList :items="relatedNews" small :loading="loading" :max-height="maxHeight">
                 <template #header>
                   <NewsListHeader label="Berita Terkait" class="mb-2" />
                 </template>
@@ -48,7 +48,8 @@ export default {
   data () {
     return {
       news: {},
-      relatedNews: []
+      relatedNews: [],
+      maxHeight: null
     }
   },
   async fetch () {
@@ -157,6 +158,14 @@ export default {
         description: this.news?.excerpt || ''
       }
     }
+  },
+  mounted () {
+    const viewportHeight = document.documentElement.clientHeight
+    /**
+     *  `300px` is the estimated total height of the navbar,
+     *  social media share buttons, and the gap between components
+     */
+    this.maxHeight = Math.floor(viewportHeight - 300)
   },
   methods: {
     async fetchRelatedNews () {


### PR DESCRIPTION
#### Related
- [T30 - Sticky -Berita Terkait - FE](https://airtable.com/app7SdZInMN1pG6ZL/tblB9pTkT5LrZHnIp/viwQAZLJD0D9EGBbX/rec4LzokIcYmXEeIS?blocks=hide)
- [S19A6 - Sidebar 
](https://airtable.com/app7SdZInMN1pG6ZL/tblLy5A3qYF19fj1u/viwDUthwzD6mc5jka/recj2W1SWmiVoqyJK?blocks=hide)

#### Changes
- minor refactor and fix styling on `NewsListHeader` component
- add ability to adjust `max-height` and scroll on `NewsList` component
- adjust height of **related news** section on news detail page based on client _viewport_

#### Preview
**Before**
![Peek 2021-12-06 11-42](https://user-images.githubusercontent.com/33661143/144788590-c8a7c82b-f176-4906-bcd5-bce3dd012ed8.gif)

**After**
![Peek 2021-12-06 11-43](https://user-images.githubusercontent.com/33661143/144788586-5ac8b824-1a11-4456-b614-b2729deb65c2.gif)

### Evidence
title: Improve related news section
project: Portal Jabar
participants: @Ibwedagama @maruf12 @maulanayuseph @yoslie @bangunbagustapa 

