### PR TITLE
Improve: change Link component to anchor tag

### DIFF
--- a/components/News/Header/index.vue
+++ b/components/News/Header/index.vue
@@ -43,11 +43,11 @@
                   </div>
                 </div>
                 <div class="flex justify-between items-center">
-                  <Link :link="`/berita/${item.slug}`">
+                  <a :href="`/berita/${item.slug}`">
                     <button type="button" class="border border-white border-opacity-30 px-4 py-2 rounded-lg">
                       Baca Selengkapnya
                     </button>
-                  </Link>
+                  </a>
                   <div class="flex items-center gap-4">
                     <div class="cursor-pointer" @click="prev">
                       <Icon name="chevron-left" size="10px" />
@@ -66,7 +66,14 @@
                   Berita Terkait
                 </p>
                 <div class="flex flex-col gap-2">
-                  <Link v-for="news of item.related_news.slice(0, 4)" :key="news.id" :link="`/berita/${news.slug}`" class="group">
+                  <a
+                    v-for="news of item.related_news.slice(0, 4)"
+                    :key="news.id"
+                    :href="`/berita/${news.slug}`"
+                    :aria-label="news.title"
+                    :title="news.title"
+                    class="group"
+                  >
                     <div class="flex gap-4 p-2 bg-white bg-opacity-0 group-hover:bg-opacity-5 rounded-xl">
                       <div class="flex-shrink-0 overflow-hidden rounded-xl" style="width: 92px; height: 92px;">
                         <img
@@ -92,7 +99,7 @@
                         </div>
                       </div>
                     </div>
-                  </Link>
+                  </a>
                 </div>
               </div>
             </BaseContainer>

--- a/components/News/Headline/index.vue
+++ b/components/News/Headline/index.vue
@@ -22,7 +22,7 @@
       </div>
     </template>
     <template v-else>
-      <nuxt-link :to="`/berita/${item.slug}`" :aria-label="item.title">
+      <a :href="`/berita/${item.slug}`" :aria-label="item.title" :title="item.title">
         <div
           ref="news-headline-image"
           class="cursor-pointer w-full h-full bg-cover bg-no-repeat bg-center transition-transform
@@ -30,7 +30,7 @@
           :class="loading ?'bg-gray-200 animate-pulse' : ''"
           :style="`background-image: url('${item.image}')`"
         />
-      </nuxt-link>
+      </a>
       <div
         ref="news-headline-meta"
         class="absolute bottom-0 w-full bg-black bg-opacity-50 transition duration-500 ease-in-out
@@ -62,14 +62,14 @@
             </div>
           </div>
           <div class="flex justify-between items-center">
-            <nuxt-link
+            <a
               ref="news-headline-button"
               class="text-sm border border-white border-opacity-30 px-4 py-2 rounded-lg"
-              :to="`/berita/${item.slug}`"
+              :href="`/berita/${item.slug}`"
               :aria-label="item.title"
             >
               Baca Selengkapnya
-            </nuxt-link>
+            </a>
           </div>
         </div>
       </div>

--- a/components/News/Item/index.vue
+++ b/components/News/Item/index.vue
@@ -12,7 +12,7 @@
       :class="loading ? 'bg-gray-200 animate-pulse' : ''"
       :style="imageSize"
     >
-      <Link :link="`/berita/${item.slug}`">
+      <a :href="`/berita/${item.slug}`" :aria-label="item.title" :title="item.title">
         <img
           v-show="!loading"
           ref="news-item-image"
@@ -22,7 +22,7 @@
           group-hover:transform group-hover:scale-125"
           :style="imageSize"
         >
-      </Link>
+      </a>
     </div>
     <div class="w-full flex flex-col items-start justify-center">
       <!-- skeleton -->
@@ -31,7 +31,7 @@
         <div class="w-1/2 h-4 bg-gray-200 animate-pulse rounded-md mb-2" />
       </div>
       <template v-else>
-        <Link :link="`/berita/${item.slug}`">
+        <a :href="`/berita/${item.slug}`" :aria-label="item.title" :title="item.title">
           <h2
             ref="news-item-title"
             class="cursor-pointer font-lato font-medium text-blue-gray-800 mb-2
@@ -40,7 +40,7 @@
           >
             {{ item.title }}
           </h2>
-        </Link>
+        </a>
         <p ref="news-item-meta" class="font-normal text-xs leading-5 text-gray-700">
           <span class="group-hover:text-blue-gray-800 capitalize">{{ item.category }}</span> | {{ formatDate(item.date) }}
         </p>


### PR DESCRIPTION
#### Overview
After a discussion with @bangunbagustapa we agree that any link that leads to `news detail` page should be using `<a>` tag to ensure the page will be _server-rendered_. The reason behind these decisions are as follows:

1. we don't really need any client side data fetching on `news detail`' page
2. we don't feel it necessary to render any skeletons on this page 😅 
3. _server-rendered_ page ensure there is a minimal amount of _layout shifting_ because all the data already fetched on the server
4. it's a good SEO strategy to render any content on the server
5. default browser loading state is not as bad as we think 😄 

Any feedback on this matter is very appreciated

#### Changes
- change `Link` and `nuxt-link` component to `<a>` tag
- add `aria-label` and `title` to improve accessibility

#### Evidence
title: change link component to anchor tag
project: Portal Jabar
participants: @Ibwedagama 