### PR TITLE
Setup cache for static directory

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -19,6 +19,14 @@ export default {
     ]
   },
 
+  render: {
+    // Setting up cache for 'static' directory - a year in milliseconds
+    // https://web.dev/uses-long-cache-ttl
+    static: {
+      maxAge: 60 * 60 * 24 * 365 * 1000
+    }
+  },
+
   // Global CSS: https://go.nuxtjs.dev/config-css
   css: [
   ],


### PR DESCRIPTION
#### Overview
Apparently, Nuxt didn't set up a _cache policy_ for images stored in the `static` folder because this directory is not processed by `webpack`. The problem is all of the images and icons used on **Portal Jabar** are stored in `static` folder, this causes the app to re-download the images and icons every time users refresh the page. 

To solve this problem we can use one of the following solutions:
1. move all images and icons to `assets` folder
2. set up a cache policy on `nuxt.config.js`

the quick fix to this problem is to use the second option, which is to set up a cache policy on `static` directory.

ref:
[Nuxt.js Docs on Static Directory](https://nuxtjs.org/docs/directory-structure/static/)
[How do I solve the nuxt static image caching problem?](https://stackoverflow.com/questions/69208407/how-do-i-solve-the-nuxt-static-image-caching-problem)
[Serve static assets with an efficient cache policy - Nuxt.js + GAE](https://stackoverflow.com/questions/61662857/serve-static-assets-with-an-efficient-cache-policy-nuxt-js-gae)

#### Preview
**Before**
![Screenshot from 2021-12-07 13-27-15](https://user-images.githubusercontent.com/33661143/144984235-32063cf8-8b4a-4e47-9788-b1d9dfeaddfb.png)

**After**
![Screenshot from 2021-12-07 13-25-18](https://user-images.githubusercontent.com/33661143/144984258-fea5c0fa-07ac-4334-9118-61d151cecd4a.png)



### Evidence
title: Setup cache policy for static directory
project: Portal Jabar
participants: @Ibwedagama @bangunbagustapa @maulanayuseph @adzharamrullah