### PR TITLE
Fix css class conflict

### DIFF
--- a/components/FeaturedProgram/Filter/index.vue
+++ b/components/FeaturedProgram/Filter/index.vue
@@ -140,10 +140,10 @@ export default {
 /**
  * Override default jds-popover styling
  */
-.jds-popover__content {
+.featured-program__filter .jds-popover__content {
   margin-top: 8px !important;
 }
-.jds-popover-dropdown__body {
+.featured-program__filter .jds-popover-dropdown__body {
   display: flex !important;
   flex-direction: column !important;
   gap: 8px !important;

--- a/components/Pagination/index.vue
+++ b/components/Pagination/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="max-h-[44px] overflow-hidden">
+  <div class="pagination max-h-[44px] overflow-hidden">
     <jds-pagination
       v-bind="$props"
       @previous-page="$emit('previous-page', $event)"
@@ -40,13 +40,13 @@ export default {
 </script>
 
 <style>
-.jds-input-text__input-wrapper {
+.pagination .jds-input-text__input-wrapper {
   height: 36px !important;
 }
-.jds-options__filter {
+.pagination .jds-options__filter {
   width: 100% !important;
 }
-.jds-popover__content {
+.pagination .jds-popover__content {
   z-index: 20 !important;
 }
 </style>

--- a/components/Search/Toolbar/index.vue
+++ b/components/Search/Toolbar/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="relative h-[38px] flex justify-between">
+  <section class="toolbar relative h-[38px] flex justify-between">
     <!-- Results Counter -->
     <div class="flex w-max items-center">
       <p class="font-roboto text-base leading-5 text-blue-gray-300">
@@ -94,7 +94,7 @@ export default {
 </script>
 
 <style>
-.jds-input-text__input-wrapper {
+.toolbar .jds-input-text__input-wrapper {
   max-width: 124px !important;
 }
 </style>


### PR DESCRIPTION
#### Overview
There is a CSS conflict when I try to override `jds-design-system` component styling. To avoid these conflicts, I try to add a class to each component that wraps `jds-design-system` components to improve specificity.

#### Changes
- add class to `Pagination` component
- add class to `FeaturedProgramFilter` component
- add class to `SearchToolbar` component

### Evidence
title: fix CSS class conflict
project: Portal Jabar
participants: @Ibwedagama @maulanayuseph @maruf12 @adzharamrullah @yoslie 


