### PR TITLE
Refactor: show news data with status published

### DIFF
--- a/components/LatestNews/Preview/index.vue
+++ b/components/LatestNews/Preview/index.vue
@@ -68,11 +68,13 @@ export default {
     }
   },
   async fetch () {
-    const perPage = `per_page=${this.perPage}`
-    const filterByHighlightNews = 'highlight=true'
-    const queryParams = `?${filterByHighlightNews}&${perPage}`
+    const params = {
+      per_page: this.perPage,
+      highlight: true,
+      status: 'PUBLISHED'
+    }
 
-    const response = await this.$axios.$get(`/v1/news${queryParams}`)
+    const response = await this.$axios.$get('/v1/news', { params })
     this.items = response.data
   },
   activated () {

--- a/components/LatestNews/Tab/index.vue
+++ b/components/LatestNews/Tab/index.vue
@@ -47,15 +47,19 @@ export default {
     }
   },
   async fetch () {
-    const perPage = `per_page=${this.perPage}`
-    const sortByMostPopularNews = 'sort_by=views'
-    let queryParams = `?${perPage}`
-
-    if (this.selectedTab === 'terpopuler') {
-      queryParams = `?${sortByMostPopularNews}&${perPage}`
+    let params = {
+      per_page: this.perPage,
+      status: 'PUBLISHED'
     }
 
-    const response = await this.$axios.$get(`/v1/news${queryParams}`)
+    if (this.selectedTab === 'terpopuler') {
+      params = {
+        ...params,
+        sort_by: 'views'
+      }
+    }
+
+    const response = await this.$axios.$get('/v1/news', { params })
     this.items = response.data
   },
   activated () {

--- a/components/News/index.vue
+++ b/components/News/index.vue
@@ -81,7 +81,8 @@ export default {
   async fetch () {
     const params = {
       cat: this.currentCategory,
-      sort_order: 'desc'
+      sort_order: 'desc',
+      status: 'PUBLISHED'
     }
 
     try {
@@ -154,7 +155,8 @@ export default {
         page: this.pagination.currentPage,
         sort_order: 'desc',
         per_page: this.pagination.itemsPerPage,
-        cat: this.currentCategory
+        cat: this.currentCategory,
+        status: 'PUBLISHED'
       }
 
       try {

--- a/components/NewsDetail/index.vue
+++ b/components/NewsDetail/index.vue
@@ -174,7 +174,8 @@ export default {
           sort_order: 'desc',
           per_page: 5,
           cat: this.news.category,
-          exclude: this.news.id
+          exclude: this.news.id,
+          status: 'PUBLISHED'
         }
 
         const response = await this.$axios.get('/v1/news', { params })


### PR DESCRIPTION
#### Related
- [T98 - Berita - Arsipkan berita - FE](https://airtable.com/app7SdZInMN1pG6ZL/tblB9pTkT5LrZHnIp/viwQAZLJD0D9EGBbX/rec6yDO4I9Rwmgr28?blocks=hide)

#### Overview
- news with `DRAFT` status still showing on the public website
- to fix this issue we need to filter the news with `PUBLISHED` status

### Evidence
title: refactor show news data with status published
project: Portal Jabar
participants: @Ibwedagama @maulanayuseph @bangunbagustapa @naufalihsank @yoslie 