### PR TITLE
fix: news sort by and sort order

### DIFF
--- a/components/LatestNews/Preview/index.vue
+++ b/components/LatestNews/Preview/index.vue
@@ -71,7 +71,9 @@ export default {
     const params = {
       per_page: this.perPage,
       highlight: true,
-      status: 'PUBLISHED'
+      status: 'PUBLISHED',
+      sort_by: 'published_at',
+      sort_order: 'DESC'
     }
 
     const response = await this.$axios.$get('/v1/news', { params })

--- a/components/LatestNews/Tab/index.vue
+++ b/components/LatestNews/Tab/index.vue
@@ -49,7 +49,9 @@ export default {
   async fetch () {
     let params = {
       per_page: this.perPage,
-      status: 'PUBLISHED'
+      status: 'PUBLISHED',
+      sort_by: 'published_at',
+      sort_order: 'DESC'
     }
 
     if (this.selectedTab === 'terpopuler') {

--- a/components/News/index.vue
+++ b/components/News/index.vue
@@ -81,8 +81,9 @@ export default {
   async fetch () {
     const params = {
       cat: this.currentCategory,
-      sort_order: 'desc',
-      status: 'PUBLISHED'
+      status: 'PUBLISHED',
+      sort_by: 'published_at',
+      sort_order: 'DESC'
     }
 
     try {
@@ -147,13 +148,14 @@ export default {
     mapItems (items) {
       return items.map(item => ({
         ...item,
-        date: new Date(item.created_at)
+        date: new Date(item.published_at)
       }))
     },
     async fetchMainNews () {
       const params = {
         page: this.pagination.currentPage,
-        sort_order: 'desc',
+        sort_by: 'published_at',
+        sort_order: 'DESC',
         per_page: this.pagination.itemsPerPage,
         cat: this.currentCategory,
         status: 'PUBLISHED'

--- a/components/NewsDetail/index.vue
+++ b/components/NewsDetail/index.vue
@@ -176,7 +176,8 @@ export default {
     async fetchRelatedNews () {
       try {
         const params = {
-          sort_order: 'desc',
+          sort_by: 'published_at',
+          sort_order: 'DESC',
           per_page: 5,
           cat: this.news.category,
           exclude: this.news.id,


### PR DESCRIPTION
### Changes
- add `sort_by` and `sort_order` params on every network request to `/news` endpoint

### Evidence
title: fix news sort by and sort order
project: Portal Jabar
participants: @Ibwedagama 
