### PR TITLE
fix (jabar-achievements): fix pagination bug when category filter change

### DIFF
--- a/components/Profile/JabarAchievements/Item/index.vue
+++ b/components/Profile/JabarAchievements/Item/index.vue
@@ -20,13 +20,12 @@
       <p class="font-lato text-xs font-normal text-[#415C84] leading-5 line-clamp-2 mb-3">
         {{ description }}
       </p>
-      <nuxt-link
-        to="#"
-        class="rounded-md px-[10px] py-2 text-xs font-normal text-gray-700 bg-gray-100 cursor-pointer
+      <div
+        class="inline-block rounded-md px-[10px] py-2 text-xs font-normal text-gray-700 bg-gray-100
           hover:text-green-700 hover:bg-green-50"
       >
         {{ category }}
-      </nuxt-link>
+      </div>
     </div>
   </li>
 </template>

--- a/components/Profile/JabarAchievements/index.vue
+++ b/components/Profile/JabarAchievements/index.vue
@@ -155,6 +155,10 @@ export default {
       } else {
         this.categories = []
       }
+      this.pagination = {
+        ...this.pagination,
+        currentPage: 1
+      }
       this.$fetch()
     },
     onChangeSort (sortOrder) {


### PR DESCRIPTION
### Related
- [T191 - Daftar prestasi jabar - Menampilkan empty state pada saat mengubah pilihan kategori di halaman ke-2 atau seterusnya  - FE](https://airtable.com/app7SdZInMN1pG6ZL/tblB9pTkT5LrZHnIp/viwQAZLJD0D9EGBbX/rec3RdLtDez8MfVWO?blocks=hide)
- [T201 - Kategori di halaman prestasi jabar masih clickable - FE
](https://airtable.com/app7SdZInMN1pG6ZL/tblB9pTkT5LrZHnIp/viwQAZLJD0D9EGBbX/recIjAPp24ajJHZwq?blocks=hide)

### Changes
- fix (jabar-achievements): fix pagination bug when category filter change
- refactor (jabar-achievements): remove link on item's category