### PR TITLE
refactor (Dockerfile): change node-js image url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.4-slim
+FROM registry.digitalservice.id/proxyjds/library/node:14.15.4-slim
 
 WORKDIR /app
 COPY package*.json ./


### PR DESCRIPTION
### Overview
- change Dockerfile's node js image URL using jabardigitalservice proxy to prevent pull rate limit [ref](https://www.docker.com/increase-rate-limit)

### Evidence
title: refactor Dockerfile node-js image URL
project: Portal Jabar
participants: @Ibwedagama 
