### PR TITLE
fix (nuxt.config): remove meta maximum-scale to improve accessibility

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -7,7 +7,7 @@ export default {
     },
     meta: [
       { charset: 'utf-8' },
-      { name: 'viewport', content: 'width=device-width, initial-scale=1, maximum-scale=1' },
+      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       { hid: 'description', name: 'description', content: 'Portal ini menyediakan informasi resmi, akses ke berbagai layanan publik, dan tempat menyampaikan aspirasi mengenai program dari Pemerintah Daerah Provinsi Jawa Barat.' },
       { name: 'format-detection', content: 'telephone=no' }
     ],


### PR DESCRIPTION
### Overview
Disabling zoom with meta `user-scalable : no` or `maximum-scale : 1` is considered to be bad practice and affects the Accessibility score

[ref](https://web.dev/meta-viewport/?utm_source=lighthouse&utm_medium=devtools)

### Evidence
title: remove meta maximum-scale to improve accessibility
project: Portal Jabar
participants: @Ibwedagama @maruf12 @agunghide @naufalihsank @yoslie @doohanas 